### PR TITLE
Add timeout for auto-completion

### DIFF
--- a/src/pyfx/app.py
+++ b/src/pyfx/app.py
@@ -11,6 +11,7 @@ Example
    PyfxApp(data=data).run()
 """
 import sys
+from concurrent.futures.thread import ThreadPoolExecutor
 
 import urwid
 from loguru import logger
@@ -49,7 +50,8 @@ class PyfxApp:
         self._dispatcher.register("complete", self._model.complete)
 
         # UI part
-        self._client = Client(self._dispatcher)
+        self._thread_pool_executor = ThreadPoolExecutor()
+        self._client = Client(self._dispatcher, self._thread_pool_executor)
         # Specify the `input` to force Screen reload the value for sys.stdin
         # as sys.stdin may be redirected. E.g., when pyfx is using with pipe,
         # we replaced the sys.stdin at the CLI level
@@ -158,7 +160,7 @@ class PyfxApp:
                 error("Unknown exception encountered in app.run, "
                       "exit with {}", e)
         finally:
-            self._client.shutdown(wait=True)
+            self._thread_pool_executor.shutdown(wait=True)
 
     def __create_screen(self):
         """

--- a/src/pyfx/service/client.py
+++ b/src/pyfx/service/client.py
@@ -1,20 +1,19 @@
 import asyncio
 
-from concurrent.futures import ThreadPoolExecutor
-
 
 class Client:
-    def __init__(self, dispatcher):
+    def __init__(self, dispatcher, executor):
         self._dispatcher = dispatcher
-        self._executor = ThreadPoolExecutor()
+        self._executor = executor
 
-    def shutdown(self, wait):
-        self._executor.shutdown(wait=wait)
+    def invoke(self, path, *args):
+        return asyncio.get_event_loop().run_until_complete(
+            self._invoke(path, *args))
 
-    async def invoke(self, path, *args):
+    def invoke_with_timeout(self, timeout, path, *args):
+        return asyncio.get_event_loop().run_until_complete(
+            asyncio.wait_for(self._invoke(path, *args), timeout=timeout))
+
+    async def _invoke(self, path, *args):
         return await asyncio.get_event_loop().run_in_executor(
-            self._executor,
-            self._dispatcher.invoke,
-            path,
-            *args
-        )
+            self._executor, self._dispatcher.invoke, path, *args)


### PR DESCRIPTION
When data is super large, the UI may freeze while performing autocompletion. 
This change adds a 200 ms timeout to the autocompletion request and gives up the autocompletion when timeout, which makes the query bar more usable for a larger data file.