### PR TITLE
Fix - warning display is not restored to query bar

### DIFF
--- a/src/pyfx/view/common/frame.py
+++ b/src/pyfx/view/common/frame.py
@@ -76,7 +76,7 @@ class Frame(urwid.Widget, urwid.WidgetContainerMixin):
         self._info_line = self._create_info_widget(
             self._focus_widget.help_message())
 
-        self._backup = None
+        self._backups = []
 
     @property
     def buffer(self):
@@ -148,14 +148,14 @@ class Frame(urwid.Widget, urwid.WidgetContainerMixin):
         self._invalidate()
 
     def create_snapshot(self):
-        self._backup = FrameSnapshot(self._current_buffer,
-                                     self._current_mini_buffer)
+        self._backups.append(
+            FrameSnapshot(self._current_buffer, self._current_mini_buffer))
 
-    def restore(self):
-        self._current_buffer = self._backup.buffer
-        self._current_mini_buffer = self._backup.mini_buffer
+    def restore(self, index):
+        self._current_buffer = self._backups[index].buffer
+        self._current_mini_buffer = self._backups[index].mini_buffer
 
-        self._backup = None
+        self._backups.clear()
         self._invalidate()
 
     def render(self, size, focus=False):

--- a/src/pyfx/view/view_frame.py
+++ b/src/pyfx/view/view_frame.py
@@ -34,9 +34,13 @@ class ViewFrame(PopUpLauncher):
     def switch(self, widget_name, focus):
         if focus:
             self.original_widget.set_focus(widget_name)
-        else:
-            self.original_widget.create_snapshot()
-            self.original_widget.set_no_focus(widget_name)
+            return
+
+        # `switch but no focus` indicates that this is a temporary widget change
+        # in the frame we need to create a snapshot of the current state and
+        # then reset it later using `original_widget#restore`.
+        self.original_widget.create_snapshot()
+        self.original_widget.set_no_focus(widget_name)
 
     # This is a workaround we used to be able to popup autocomplete window in
     # query bar
@@ -60,7 +64,8 @@ class ViewFrame(PopUpLauncher):
         # Handle valid keys case
         if self._pressed_unknown_key:
             self._pressed_unknown_key = False
-            # Press a valid keys, reset warnings
-            self.original_widget.restore()
+            # Press a valid keys, we will restore the first version of the frame
+            # as that is that when the snapshot version for the focused widget
+            self.original_widget.restore(0)
 
         return None

--- a/src/pyfx/view/view_manager.py
+++ b/src/pyfx/view/view_manager.py
@@ -49,8 +49,13 @@ class View:
                 # work around for urwid.MainLoop#process_input does not apply
                 # input filter
                 key = self._loop.input_filter([key], None)
-                if len(key) >= 1 and (not self._loop.process_input(key)):
-                    return False, f"keys[{index}]: {key} is not handled"
+
+                if len(key) == 0:
+                    continue
+                elif self._loop.process_input(key):
+                    continue
+
+                return False, f"keys[{index}]: {key} is not handled"
         except urwid.ExitMainLoop:
             pass
         finally:

--- a/tests/intergration_tests/test_warning.py
+++ b/tests/intergration_tests/test_warning.py
@@ -62,6 +62,50 @@ class WarningIT(unittest.TestCase):
         self.assertEqual(app._query_bar,
                          app._view_frame.original_widget.mini_buffer)
 
+    def test_warning_bar_in_json_browser_with_multiple_key_error(self):
+        """
+        Test warning update and show up.
+        """
+        data = {
+            "alice": "0",
+            "bob": "1",
+            "chuck": "2",
+            "daniel": "3"
+        }
+
+        app = PyfxApp(data=data, config=self.config_path)
+        view = app._view
+        keymap = app._keymapper
+
+        for _ in range(3):
+            # Press the invalid key multiple times
+            inputs = split([
+                # enter an undefined key in json browser
+                'ctrl q'
+            ], keymap.global_command_key)
+
+            result, err = view.process_input(inputs)
+            self.assertFalse(result, err)
+            self.assertEqual(app._warning_bar,
+                             app._view_frame.original_widget.mini_buffer)
+            self.assertEqual(app._warning_bar.message(),
+                             "Unknown key `ctrl q`. Press `?` for all "
+                             "supported keys.")
+
+        inputs = split([
+            # enter valid key in json browser
+            keymap.json_browser.open_help_page,
+            # close help pop up
+            keymap.help_popup.exit,
+            # exit Pyfx
+            keymap.json_browser.exit
+        ], keymap.global_command_key)
+
+        result, err = view.process_input(inputs)
+        self.assertTrue(result, err)
+        self.assertEqual(app._query_bar,
+                         app._view_frame.original_widget.mini_buffer)
+
     def test_warning_bar_in_query_bar(self):
         """
         Test warning update and show up.


### PR DESCRIPTION
How to reproduce:
After pressing invalid keys multiple times and then press a valid key