### PR TITLE
user super() rather than self.__super

### DIFF
--- a/src/pyfx/view/common/frame.py
+++ b/src/pyfx/view/common/frame.py
@@ -62,7 +62,7 @@ class Frame(urwid.Widget, urwid.WidgetContainerMixin):
             `current_mini_buffer`(string): the key of current focused widget
                 for mini buffer in mini buffers.
         """
-        self.__super.__init__()
+        super().__init__()
 
         self._screen = screen
 


### PR DESCRIPTION
Otherwise some tests fail with

    AttributeError: 'Frame' object has no attribute '_Frame__super'